### PR TITLE
Dont set default publisher when community site is false

### DIFF
--- a/lib/emeril/releaser.rb
+++ b/lib/emeril/releaser.rb
@@ -37,10 +37,7 @@ module Emeril
       @category = options.fetch(:category) { default_category }
       @git_tagger = options.fetch(:git_tagger) { default_git_tagger }
       @publish_to_community = options.fetch(:publish_to_community) { true }
-
-      if publish_to_community
-        @publisher = options.fetch(:publisher) { default_publisher }
-      end
+      set_publisher(options.fetch(:publisher, nil)) if publish_to_community
     end
 
     # Tags and releases a cookbook.
@@ -78,6 +75,10 @@ module Emeril
         :name => metadata[:name],
         :category => category
       )
+    end
+
+    def set_publisher(publisher)
+      @publisher = publisher || default_publisher
     end
 
     def default_category

--- a/lib/emeril/releaser.rb
+++ b/lib/emeril/releaser.rb
@@ -36,8 +36,11 @@ module Emeril
       @metadata = options.fetch(:metadata) { default_metadata }
       @category = options.fetch(:category) { default_category }
       @git_tagger = options.fetch(:git_tagger) { default_git_tagger }
-      @publisher = options.fetch(:publisher) { default_publisher }
       @publish_to_community = options.fetch(:publish_to_community) { true }
+
+      if publish_to_community
+        @publisher = options.fetch(:publisher) { default_publisher }
+      end
     end
 
     # Tags and releases a cookbook.

--- a/spec/emeril/releaser_spec.rb
+++ b/spec/emeril/releaser_spec.rb
@@ -99,11 +99,7 @@ describe Emeril::Releaser do
     end
 
     it "does not call Publisher when disabling community site publishing" do
-      Emeril::Publisher.expects(:new).never do |opts|
-        opts[:source_path] == source_path &&
-          opts[:name] == metadata[:name] &&
-          opts[:category] == category
-      end
+      Emeril::Publisher.expects(:new).never
 
       Emeril::Releaser.new(
         :source_path => source_path,

--- a/spec/emeril/releaser_spec.rb
+++ b/spec/emeril/releaser_spec.rb
@@ -98,6 +98,21 @@ describe Emeril::Releaser do
       )
     end
 
+    it "does not call Publisher when disabling community site publishing" do
+      Emeril::Publisher.expects(:new).never do |opts|
+        opts[:source_path] == source_path &&
+          opts[:name] == metadata[:name] &&
+          opts[:category] == category
+      end
+
+      Emeril::Releaser.new(
+        :source_path => source_path,
+        :metadata => metadata,
+        :category => category,
+        :publish_to_community => false
+      )
+    end
+
     it "disables the git version tag prefix" do
       Emeril::GitTagger.expects(:new).with do |opts|
         opts[:tag_prefix] == false


### PR DESCRIPTION
@fnichol I noticed that publisher was still being called even when community site publishing was disabled.  This PR is to avoid that.

I played with a few options in releaser.rb.  The first was:

``` ruby
@publisher = options.fetch(:publisher) { default_publisher } if publish_to_community
```

but it was too long and tailor let me know it! :smile: 

Also tried an if statement in the initializer:

``` ruby
if publish_to_community
  @publisher = options.fetch(:publisher) { default_publisher }
end
```

but it just didn't feel as clean since everything else was a one liner.  I can change it back though if that's what you prefer.
